### PR TITLE
Fixed spacing between lines.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@
 
 ### Linux ###
 *~
-
 # temporary files which can be created if a process still has a handle open of a deleted file
 .fuse_hidden*
 
@@ -154,6 +153,7 @@ dist
 # Stores VSCode versions used for testing VSCode extensions
 .vscode-test
 .prettierrc
+
 ### Windows ###
 # Windows thumbnail cache files
 Thumbs.db

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 
 ### Linux ###
 *~
+
 # temporary files which can be created if a process still has a handle open of a deleted file
 .fuse_hidden*
 


### PR DESCRIPTION
## I have made one change.


### Before:
```.gitignore
# Stores VSCode versions used for testing VSCode extensions
.vscode-test
.prettierrc
### Windows ###
# Windows thumbnail cache files
Thumbs.db
Thumbs.db:encryptable
ehthumbs.db
ehthumbs_vista.db
```

### After:
```.gitignore
# Stores VSCode versions used for testing VSCode extensions
.vscode-test
.prettierrc

### Windows ###
# Windows thumbnail cache files
Thumbs.db
Thumbs.db:encryptable
ehthumbs.db
ehthumbs_vista.db
```

#### This improves readability.